### PR TITLE
General Improvements 2

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [dev, main]
 
 permissions:
   contents: write

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -5,9 +5,46 @@ on:
     types: [published]
 
 jobs:
-  build-n-publish:
-    name: Build and publish to PyPI
+  publish-testpypi:
+    name: Publish to TestPyPI
     runs-on: ubuntu-latest
+
+    if: github.event.release.target_commitish == 'dev'
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/epics/
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install build dependencies
+        run: python -m pip install --upgrade build
+
+      - name: Build wheel and source distribution
+        run: python -m build
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+
+    if: github.event.release.target_commitish == 'main'
 
     environment:
       name: pypi


### PR DESCRIPTION
This pull request updates the Python publishing workflow to split publishing to TestPyPI and PyPI into separate jobs, with each job triggered based on the target branch of the release. The workflow now ensures that releases from the `dev` branch are published to TestPyPI and releases from the `main` branch are published to PyPI.

**Workflow improvements:**

* Added a new `publish-testpypi` job that publishes to TestPyPI when the release is targeting the `dev` branch, including appropriate environment configuration and permissions.
* Updated the `publish-pypi` job to only run when the release is targeting the `main` branch.